### PR TITLE
Add the ability for image scanning and ability to toggle image tag mutability

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,11 @@
 resource "aws_ecr_repository" "default" {
-  name = var.ecr_repo_name
+  name                 = var.ecr_repo_name
+  image_tag_mutability = var.image_tag_mutability
+
+  image_scanning_configuration {
+    scan_on_push = var.scan_on_push
+  }
+
   tags = var.tags
 }
 
@@ -45,8 +51,8 @@ data "aws_iam_policy_document" "ecs_ecr_read_perms" {
       type = "AWS"
 
       identifiers = concat(
-        var.allowed_read_principals,
-        var.allowed_write_principals
+      var.allowed_read_principals,
+      var.allowed_write_principals
       )
     }
   }

--- a/variables.tf
+++ b/variables.tf
@@ -22,7 +22,7 @@ variable "enable_ecr_lifecycle" {
 
 variable "image_tag_mutability" {
   description = "Sets if tags for images can be modified once they are created"
-  default     = "IMMUTABLE"
+  default     = "MUTABLE"
   type        = string
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -20,10 +20,22 @@ variable "enable_ecr_lifecycle" {
   type        = bool
 }
 
+variable "image_tag_mutability" {
+  description = "Sets if tags for images can be modified once they are created"
+  default     = "IMMUTABLE"
+  type        = string
+}
+
 variable "max_images" {
   description = "The maximum number of images the repository should contain"
   default     = 100
   type        = number
+}
+
+variable "scan_on_push" {
+  description = "Scan the Docker image when it is pushed to the ECR repository"
+  default     = true
+  type        = bool
 }
 
 variable "tags" {


### PR DESCRIPTION
Enables [vulnerability scanning](https://docs.aws.amazon.com/AmazonECR/latest/userguide/image-scanning.html) on docker images which are pushed to the ECR repository. 

Image tag mutability allows you to push the same tag, which is useful when the same build is being triggered.